### PR TITLE
minimal working python 3 support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -55,3 +55,8 @@ You can run this example in the example.py file in the root folder.
 
 ## Implementation Details
 The protocol is designed to be as small and fast as possible.  Python objects are serialized using [MsgPack](http://msgpack.org/).  All calls must fit within 8K (generally small enough to fit in one datagram packet).
+
+## Compatibility
+With version 2.0 compatibility is broken with previous versions. In version 2.0 the method name when making a remote call is always packed as a unicode string. In previous versions, the type of string that method name was depended on the Python version. In order to make instances running on Python 2 and Python 3 compatible with each other the method name is now encoded as a unicode string before being packed, which ensures that [u-msgpack-python](https://github.com/vsergeev/u-msgpack-python) will always pack the it the same way. See [u-msgpack-python#behaviour-notes](https://github.com/vsergeev/u-msgpack-python#behavior-notes) for more information.
+
+If you intend to have instances running on both Python 2 and Python 3 communicating with each other make sure that all strings in the arguments you send are unicode encoded as well to ensure compatibility.

--- a/example.py
+++ b/example.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from rpcudp.protocol import RPCProtocol
 from twisted.python import log
 from twisted.internet import reactor
@@ -17,9 +19,9 @@ class RPCClient(RPCProtocol):
     noisy = True
     def handleResult(self, result):
         if result[0]:
-            print "Success! %s" % result[1]
+            print("Success! %s" % result[1])
         else:
-            print "Response not received."
+            print("Response not received.")
 
 client = RPCClient()
 reactor.listenUDP(4567, client)

--- a/rpcudp/__init__.py
+++ b/rpcudp/__init__.py
@@ -1,2 +1,2 @@
-version_info = (1, 0)
+version_info = (1, 1)
 version = '.'.join(map(str, version_info))

--- a/rpcudp/__init__.py
+++ b/rpcudp/__init__.py
@@ -1,2 +1,2 @@
-version_info = (1, 1)
+version_info = (2, 0)
 version = '.'.join(map(str, version_info))

--- a/rpcudp/protocol.py
+++ b/rpcudp/protocol.py
@@ -1,5 +1,5 @@
 import umsgpack
-import random
+import os
 from hashlib import sha1
 from base64 import b64encode
 
@@ -32,9 +32,9 @@ class RPCProtocol(protocol.DatagramProtocol):
         msgID = datagram[1:21]
         data = umsgpack.unpackb(datagram[21:])
 
-        if datagram[0] == '\x00':
+        if datagram[:1] == b'\x00':
             self._acceptRequest(msgID, data, address)
-        elif datagram[0] == '\x01':
+        elif datagram[:1] == b'\x01':
             self._acceptResponse(msgID, data, address)
         else:
             # otherwise, don't know the format, don't do anything
@@ -67,7 +67,7 @@ class RPCProtocol(protocol.DatagramProtocol):
     def _sendResponse(self, response, msgID, address):
         if self.noisy:
             log.msg("sending response for msg id %s to %s" % (b64encode(msgID), address))
-        txdata = '\x01%s%s' % (msgID, umsgpack.packb(response))
+        txdata = b'\x01%s%s' % (msgID, umsgpack.packb(response))
         self.transport.write(txdata, address)
 
     def _timeout(self, msgID):
@@ -86,12 +86,12 @@ class RPCProtocol(protocol.DatagramProtocol):
             pass
 
         def func(address, *args):
-            msgID = sha1(str(random.getrandbits(255))).digest()
+            msgID = sha1(os.urandom(32)).digest()
             data = umsgpack.packb([name, args])
             if len(data) > 8192:
                 msg = "Total length of function name and arguments cannot exceed 8K"
                 raise MalformedMessage(msg)
-            txdata = '\x00%s%s' % (msgID, data)
+            txdata = b'\x00%s%s' % (msgID, data)
             if self.noisy:
                 log.msg("calling remote function %s on %s (msgid %s)" % (name, address, b64encode(msgID)))
             self.transport.write(txdata, address)

--- a/rpcudp/protocol.py
+++ b/rpcudp/protocol.py
@@ -2,6 +2,7 @@ import umsgpack
 import os
 from hashlib import sha1
 from base64 import b64encode
+from builtins import str
 
 from twisted.internet import protocol
 from twisted.internet import reactor
@@ -9,7 +10,6 @@ from twisted.internet import defer
 from twisted.python import log
 
 from rpcudp.exceptions import MalformedMessage
-
 
 class RPCProtocol(protocol.DatagramProtocol):
     noisy = False
@@ -87,7 +87,7 @@ class RPCProtocol(protocol.DatagramProtocol):
 
         def func(address, *args):
             msgID = sha1(os.urandom(32)).digest()
-            data = umsgpack.packb([name, args])
+            data = umsgpack.packb([str(name), args])
             if len(data) > 8192:
                 msg = "Total length of function name and arguments cannot exceed 8K"
                 raise MalformedMessage(msg)

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(
     license="MIT",
     url="http://github.com/bmuller/rpcudp",
     packages=find_packages(),
-    requires=["twisted.internet.protocol.DatagramProtocol", "umsgpack"],
-    install_requires=['twisted>=12.0', "u-msgpack-python>=1.5"]
+    requires=["twisted.internet.protocol.DatagramProtocol", "umsgpack", "future"],
+    install_requires=['twisted>=12.0', "u-msgpack-python>=1.5", "future>=0.6"]
 )


### PR DESCRIPTION
I wanted python 3 support for this library and started porting myself before seeing #2. However after seeing the pull request I incorporated some of the solutions in to my own, since @F483 had solved them in a better way.

However considering that #2 contains many other changes not strictly related to python 3 support I can understand why it has not been merged yet. This is an effort to separate out only the changes necessary for python 3 support, which might be easier to justify for a merge.

If you only want to consider the #2 pull request for merging, and feel that this is redundant, then feel free to close this pull request.
